### PR TITLE
3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Modular-Character-Controller-for-Godot
+# Modular-Character-Controller-for-Godot v3.0.1
 **Compatible Godot Versions:** 4.4, 4.5, 4.6.1 \
 **Contact:** pantheradigitalonline@gmail.com \
 **Links:**
@@ -161,7 +161,7 @@ func _unhandled_input(event: InputEvent) -> void:
 
 ## Debug
 ### UI
-A [UI debugger](addons/modular_character_controller/debug/scenes/action_tree_debug_ui.tscn) is provided. It works with and without ActionMapRemapper. Just add the scene as a child to ActionPlayer. The UI will display all requests, the ActionNodes mapped to those requests, if the action is playing, and the names of the maps ActionMapRemapper adds.
+A [UI debugger](addons/modular_character_controller/debug/scenes/action_tree_debug_ui.tscn) is provided. It works with and without ActionMapRemapper. The UI will display all requests, the ActionNodes mapped to those requests, if the action is playing, and the names of the maps ActionMapRemapper adds.
 
 ### Logger
 ActionPlayer, ActionMapRemapper, and ActionPlayerDebugUI make use of the [CustomLogger](addons/modular_character_controller/debug/scripts/logger.gd) class to print out useful debug info if their debug variable is enabled.

--- a/addons/modular_character_controller/debug/scenes/test_scene.tscn
+++ b/addons/modular_character_controller/debug/scenes/test_scene.tscn
@@ -23,7 +23,9 @@ action_map = Dictionary[StringName, NodePath]({
 debug_log = true
 metadata/_custom_type_script = "uid://cvhum0gbo0c8b"
 
-[node name="ActionTreeDebugUi" parent="ActionPlayer" instance=ExtResource("3_huw24")]
+[node name="ActionTreeDebugUi" parent="ActionPlayer" node_paths=PackedStringArray("action_player", "action_remapper") instance=ExtResource("3_huw24")]
+action_player = NodePath("..")
+action_remapper = NodePath("../ActionMapRemapper")
 debug_log = true
 
 [node name="Move" type="Node" parent="ActionPlayer"]

--- a/addons/modular_character_controller/debug/scripts/action_player_debug_ui.gd
+++ b/addons/modular_character_controller/debug/scripts/action_player_debug_ui.gd
@@ -1,5 +1,12 @@
 extends Control
 
+## Script for UI to display [ActionPlayer] and [ActionMapRemapper].
+##
+## Shows actions, and the [ActionNodes] mapped to those actions, in [member ActionPlayer.action_map]
+## from [ActionPlayer]. If [ActionMapRemapper] is provided then its maps will be shown too. [br]
+## Adding a [NodePath] to a camera node will make it so the UI is only shown to that camera when
+## it is [member current].
+
 
 const PLAYING_COLOR_BG: Color = Color(0.133, 0.55, 0.133, 0.4)
 const PLAYING_COLOR_TXT: Color = Color(1,1,1,1)
@@ -11,6 +18,9 @@ const ACTIVE_COLOR_TXT_PROFILE: Color = Color(0.2,1,1,1)
 const INACTIVE_COLOR_BG: Color = Color(0,0,0,0.15)
 const INACTIVE_COLOR_TXT: Color = Color(1,1,1,0.6)
 
+@export var action_player: ActionPlayer
+@export var action_remapper: ActionMapRemapper
+@export_node_path("Camera2D", "Camera3D") var camera_path: NodePath
 @export var debug_log: bool
 
 var profile_ui_container: HBoxContainer
@@ -19,29 +29,46 @@ var action_ui_container: VBoxContainer
 ## { ActionNode.name: {"label":Label, "timestamp":int} }
 var label_dict: Dictionary[StringName, Dictionary] 
 
-var action_player: ActionPlayer
-var action_remapper: ActionMapRemapper
+var camera: Node
 
 
 func _ready() -> void:
 	action_ui_container = find_child("ActionContainer")
 	profile_ui_container = find_child("ProfileContainer")
 	
-	action_player = get_parent()
+	if !action_player:
+		push_warning(owner, ": ", name, " has no ActionPlayer")
+		return
 	
 	action_player.ready.connect(_late_ready, CONNECT_ONE_SHOT)
 	action_player.action_map_changed.connect(_on_action_map_changed)
 	action_player.child_entered_tree.connect(_on_action_container_child_entered) 
 	action_player.child_exiting_tree.connect(_on_action_container_child_exiting)
 	
-	var temp_array: Array = action_player.find_children("*", "ActionMapRemapper")
-	action_remapper = temp_array[0] if !temp_array.is_empty() else null
+	if camera_path:
+		camera = get_node(camera_path)
+		if camera is Camera2D or camera is Camera3D:
+			visible = camera.current
+		else:
+			camera = null
+			visible = false
+			push_warning(owner, ": ", name, " invalid Camera Node")
 	
 	if debug_log: CustomLogger._log_message(str(self) + " - READY 1/2")
 
 func _late_ready() -> void:
 	_on_action_map_changed(action_player.action_map)
 	if debug_log: CustomLogger._log_message(str(self) + " - READY 2/2")
+
+func _process(_delta: float) -> void:
+	if !camera:
+		return
+	
+	if camera.current:
+		if !visible:
+			visible = true
+	elif visible:
+		visible = false
 
 
 ## Creates a [Label] with a [ColorRect] background.

--- a/addons/modular_character_controller/scripts/action_node.gd
+++ b/addons/modular_character_controller/scripts/action_node.gd
@@ -12,12 +12,14 @@ class_name ActionNode
 ## [/codeblock]
 
 # call order:
-# play() -> can_play() -> _can_play() -> ActionCollider.handle_collision() -> _enter() -> _on_enter() -> signal enter_action -> _play() -> signal play_action
+# play() -> can_play() -> _can_play() -> signal going_to_play_action -> _enter() -> _on_enter() -> signal enter_action -> _play() -> signal play_action
 # stop() -> _stop() -> signal stop_action -> _exit() -> _on_exit() -> signal exit_action
 #
 # Natural exit: when this action calls _exit()
 # Interuption: when stop() is called in or out of this class
 
+## Emitted when [method ActionNode.play] is called, but before anything is done.
+signal going_to_play_action(action: ActionNode)
 ## Emitted when [method ActionNode.play] is called if the action is not already playing.
 signal enter_action(action: ActionNode)
 ## Emitted when [method ActionNode.play] is called.
@@ -27,6 +29,7 @@ signal stop_action(action: ActionNode)
 ## Emitted when action ends if the action is playing. Represents the action naturally stopping itself.
 signal exit_action(action: ActionNode)
 
+const HELPER_DELAY: float = 0.1
 
 @onready var _action_player: ActionPlayer = get_parent()
 
@@ -38,15 +41,33 @@ var is_playing: bool = false
 var is_enabled: bool = false
 
 
-## Helper function to be used by [ActionNode] signals. [br]
-## Exits the [param action] after a short delay using [SceneTreeTimer].
-static func delayed_exit(action: ActionNode) -> void:
-	var timer: SceneTreeTimer = action.get_tree().create_timer(0.1)
-	timer.timeout.connect(action._exit)
-
-
 func _exit_tree() -> void:
 	disable()
+
+
+#region Helper Functions
+## Helper function to be used by [ActionNode] signals. [br]
+## Exits the [ActionNode] this is called from after a short delay using [SceneTreeTimer].
+func delayed_exit_self(_action: ActionNode) -> void:
+	var timer: SceneTreeTimer = get_tree().create_timer(HELPER_DELAY)
+	timer.timeout.connect(self._exit)
+
+## Helper function to be used by [ActionNode] signals. [br]
+## Exits the [ActionNode] this is called from right away.
+func immediate_exit_self(_action: ActionNode) -> void:
+	self._exit()
+
+## Helper function to be used by [ActionNode] signals. [br]
+## Stops the [ActionNode] this is called from after a short delay using [SceneTreeTimer].
+func delayed_stop_self(_action: ActionNode) -> void:
+	var timer: SceneTreeTimer = get_tree().create_timer(HELPER_DELAY)
+	timer.timeout.connect(self.stop)
+
+## Helper function to be used by [ActionNode] signals. [br]
+## Stops the [ActionNode] this is called from right away.
+func immediate_stop_self(_action: ActionNode) -> void:
+	self.stop()
+#endregion
 
 
 ## Prepare the action to be in a playable state.
@@ -54,25 +75,22 @@ func enable() -> void:
 	is_enabled = true
 	_on_enable()
 
-## Prepare the action to be in an unplayable state. [br]
-## Performs final clean up. [br][br]
-## Emits [signal exit_action]
+## Prepare the action to be in an unplayable state. 
 func disable() -> void:
 	is_enabled = false
 	_on_disable()
-	is_playing = false
-	exit_action.emit(self)
 
 ## If this action can play.
 func can_play() -> bool:
-	return is_enabled and _on_can_play()
+	return is_enabled and _can_play()
 
 ## [param _params] is arbitrary data needed for action to play. [br][br]
-## Calls [method can_play] then handles collision with other [ActionNode]s that are playing in [ActionPlayer] using [code]_action_player.get_playing_actions()[/code]. [br]
 ## Emits [signal enter_action] if action is not playing already, then emits [signal play_action].
 func play(_params: Dictionary = {}) -> bool:
 	if !can_play(): 
 		return false
+	
+	going_to_play_action.emit(self)
 	
 	if !is_playing:
 		_enter()
@@ -122,13 +140,12 @@ func _on_enable() -> void:
 
 ## Clean up for when the action becomes unplayable, such as leaving the [SceneTree]. [br]
 ## Use for clean up of variables that should not stay set when action is disabled, AKA in a dormant state.
-## This is when the action is held somewhere but is not expected to play. [br][br]
-## Called before [member is_playing] set to [code]false[/code], and [signal exit_action].
+## This is when the action is held somewhere but is not expected to play.
 func _on_disable() -> void:
 	pass
 
 ## Override to determin if the action should play. Only called if the action is enabled.
-func _on_can_play() -> bool:
+func _can_play() -> bool:
 	return true
 
 ## Override to run code when action starts. Not called again till action is exited. [br]

--- a/addons/modular_character_controller/scripts/action_player.gd
+++ b/addons/modular_character_controller/scripts/action_player.gd
@@ -184,6 +184,14 @@ func get_actions() -> Array[ActionNode]:
 			result.push_back(_action_container[path])
 	return result
 
+## Return a [Dictionary] of [NodePath] : [ActionNode] from [member ActionPlayer.action_map].
+func get_actions_dict() -> Dictionary[NodePath, ActionNode]:
+	var result: Dictionary[NodePath, ActionNode] = {}
+	for path: NodePath in action_map.values():
+		if _action_container.has(path):
+			result[path] = _action_container[path]
+	return result
+
 ## Return an [Array] of [ActionNode]s that are currently playing.
 func get_playing_actions() -> Array[ActionNode]:
 	return _playing_actions.duplicate()

--- a/addons/script_templates/ActionNode/action.gd
+++ b/addons/script_templates/ActionNode/action.gd
@@ -11,7 +11,7 @@ func _on_enable() -> void:
 func _on_disable() -> void:
 	pass
 
-func _on_can_play() -> bool:
+func _can_play() -> bool:
 	return true
 
 func _on_enter() -> void:

--- a/addons/script_templates/ActionNode/one_shot_action.gd
+++ b/addons/script_templates/ActionNode/one_shot_action.gd
@@ -4,9 +4,8 @@ extends ActionNode
 
 
 func _ready() -> void:
-	# can also place in _play()
-	play_action.connect(func(action:ActionNode): action._exit()) # queue exit at end of play
-	#play_action.connect(delayed_exit) # queue exit after delay
+	play_action.connect(immediate_exit_self) # queue exit at end of play
+	#play_action.connect(delayed_exit_self) # queue exit after HELPER_DELAY
 
 func _can_play() -> bool:
 	return true


### PR DESCRIPTION
ACTION PLAYER:
ADDED: get_actions_dict() - organized version of get_actions()

ACTION NODE:
ADDED SIGNAL: going_to_play_action - when play() is called but before any logic happens.
CHANGED: _on_can_play() TO _can_play()
ADDED FUNCS: helper funcs - functions for connecting to Action Node signals that operate on self.
ADDED: helper_delay - variable for delay used in helper funcs.
CHANGED: disable() - no longer sets is_playing to false and does not emit exit_action.

ACTION NODE TEMPLATES:
UPDATED - small changes to account for new helper funcs and _can_play() name change.

ACTION TREE DEBUG UI
ADDED: camera compatibility - can now be given a camera node to display to, will disable visibility when the camera is not set as current.
CHANGED: does not have to be child of ActionPlayer anymore. See exported variables.